### PR TITLE
fix: better detection of existing JSX plugin

### DIFF
--- a/lib/configure-jsx-transform.js
+++ b/lib/configure-jsx-transform.js
@@ -1,37 +1,16 @@
 const VersionChecker = require('ember-cli-version-checker');
+const { hasPlugin, addPlugin } = require('ember-cli-babel-plugin-helpers');
 
 function requireTransform(transformName) {
   return require.resolve(transformName);
 }
 
-function hasPlugin(plugins, name) {
-  for (const maybePlugin of plugins) {
-    const plugin = Array.isArray(maybePlugin) ? maybePlugin[0] : maybePlugin;
-    const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
-
-    if (pluginName === name) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 module.exports = function configureJsxTransform(parent) {
-  const options = (parent.options = parent.options || {});
-
   const checker = new VersionChecker(parent).for('ember-cli-babel', 'npm');
 
-  options.babel = options.babel || {};
-  options.babel.plugins = options.babel.plugins || [];
-
   if (checker.gte('7.0.0')) {
-    if (
-      !hasPlugin(options.babel.plugins, '@babel/plugin-transform-react-jsx')
-    ) {
-      options.babel.plugins.push(
-        requireTransform('@babel/plugin-transform-react-jsx')
-      );
+    if (!hasPlugin(parent, '@babel/plugin-transform-react-jsx')) {
+      addPlugin(parent, requireTransform('@babel/plugin-transform-react-jsx'));
     }
   } else {
     parent.project.ui.writeWarnLine(

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.4.1",
+    "ember-cli-babel-plugin-helpers": "^1.0.2",
     "ember-cli-version-checker": "^3.0.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4618,7 +4618,7 @@ ember-cli-autoprefixer@^0.8.1:
     broccoli-autoprefixer "^5.0.0"
     lodash "^4.0.0"
 
-ember-cli-babel-plugin-helpers@^1.0.0:
+ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
   integrity sha512-tTWmHiIvadgtu0i+Zlb5Jnue69qO6dtACcddkRhhV+m9NfAr+2XNoTKRSeGL8QyRDhfWeo4rsK9dqPrU4PQ+8g==


### PR DESCRIPTION
This changes the addon to use `ember-cli-babel-plugin-helpers` to detect an existing instance of the JSX plugin and add it to the configuration if it does not exist. This prevents issues when installing this addon as a dependency of an Engine.